### PR TITLE
stops files being written to tar with incorrect permissions

### DIFF
--- a/archivex.go
+++ b/archivex.go
@@ -158,7 +158,7 @@ func (t *TarFile) Create(name string) error {
 // Add add byte in archive tar
 func (t *TarFile) Add(name string, file []byte) error {
 
-	hdr := &tar.Header{Name: name, Size: int64(len(file))}
+	hdr := &tar.Header{Name: name, Size: int64(len(file)), Mode: 0777}
 	if err := t.Writer.WriteHeader(hdr); err != nil {
 		return err
 	}

--- a/archivex.go
+++ b/archivex.go
@@ -173,8 +173,17 @@ func (t *TarFile) AddFile(name string) error {
 		return err
 	}
 
-	hdr := &tar.Header{Name: name, Size: int64(len(bytearq))}
-	err = t.Writer.WriteHeader(hdr)
+	info, err := os.Stat(name)
+	if err != nil {
+		return err
+	}
+
+	header, err := tar.FileInfoHeader(info, "")
+	if err != nil {
+		return err
+	}
+
+	err = t.Writer.WriteHeader(header)
 	if err != nil {
 		return err
 	}

--- a/archivex.go
+++ b/archivex.go
@@ -158,7 +158,7 @@ func (t *TarFile) Create(name string) error {
 // Add add byte in archive tar
 func (t *TarFile) Add(name string, file []byte) error {
 
-	hdr := &tar.Header{Name: name, Size: int64(len(file)), Mode: 0777}
+	hdr := &tar.Header{Name: name, Size: int64(len(file)), Mode: 0666}
 	if err := t.Writer.WriteHeader(hdr); err != nil {
 		return err
 	}

--- a/archivex_test.go
+++ b/archivex_test.go
@@ -8,6 +8,7 @@ package archivex
 
 import (
 	"fmt"
+
 	// "log"
 	"os"
 	"path"
@@ -16,9 +17,12 @@ import (
 )
 
 type archTest struct {
-	addPath string
-	include bool
-	name    string
+	addPath     string
+	include     bool
+	name        string
+	filePath    string
+	addString   string
+	addFileName string
 }
 
 type archTypeTest struct {
@@ -30,19 +34,28 @@ func Test_archivex(t *testing.T) {
 
 	dir, _ := os.Getwd()
 
+	// let's clean up the previous results, to be sure that we're not reading from an old result.
+	if err := os.RemoveAll(path.Join(dir, "/testresults")); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("cannot clean up test results directory: %v", err)
+	}
+
+	if err := os.Mkdir(path.Join(dir, "/testresults"), 0777); err != nil && !os.IsExist(err) {
+		t.Fatalf("cannot make test results directory: %v", err)
+	}
+
 	// All the different tests we want to run with different combinations of input paths and the includeCurrentFolder flag
 	tests := []archTest{
 		// absolute path
-		archTest{dir + "/testfolder/", true, "absTrailInclude"},
-		archTest{dir + "/testfolder/", false, "absTrailExclude"},
+		archTest{dir + "/testfolder/", true, "absTrailInclude", dir + "/LICENSE", "string", "filename"},
+		archTest{dir + "/testfolder/", false, "absTrailExclude", dir + "/LICENSE", "string", "filename"},
 		// relative path
-		archTest{"testfolder/", true, "relTrailInclude"},
-		archTest{"testfolder/", false, "relTrailExclude"},
+		archTest{"testfolder/", true, "relTrailInclude", "LICENSE", "string", "filename"},
+		archTest{"testfolder/", false, "relTrailExclude", "LICENSE", "string", "filename"},
 		// without trailing slashes
-		archTest{dir + "/testfolder", true, "absInclude"},
-		archTest{dir + "/testfolder", false, "absExclude"},
-		archTest{"testfolder", true, "relInclude"},
-		archTest{"testfolder", false, "relExclude"},
+		archTest{dir + "/testfolder", true, "absInclude", dir + "/LICENSE", "string", "filename"},
+		archTest{dir + "/testfolder", false, "absExclude", dir + "/LICENSE", "string", "filename"},
+		archTest{"testfolder", true, "relInclude", "LICENSE", "string", "filename"},
+		archTest{"testfolder", false, "relExclude", "LICENSE", "string", "filename"},
 	}
 
 	// We want to execute the batch of tests on both Zip and Tar
@@ -71,6 +84,17 @@ func Test_archivex(t *testing.T) {
 			// Add the files to the archive
 			if err := arch.AddAll(test.addPath, test.include); err != nil {
 				t.Fatalf("Error doing AddAll with '%s' and includeCurrentFolder = %v: %v", test.addPath, test.include, err)
+			}
+
+			// Add a file to the archive
+			if err := arch.AddFile(test.filePath); err != nil {
+				t.Fatalf("Error doing AddFile with '%s': %v", test.filePath, err)
+			}
+			//}
+
+			// Add a file to the archive
+			if err := arch.Add(test.addFileName, []byte(test.addString)); err != nil {
+				t.Fatalf("Error doing Add with '%s', '%s': %v", test.addString, test.addFileName, err)
 			}
 
 			// Close the archive


### PR DESCRIPTION
Using AddFile on a tar file incorrect sets the permissions on that file. In fact, it does not set it at all. This pull request sets the permission correctly by setting it directly from the FileInfo, grabbed via os.Stat(). This is how it is set in AddAll, which sets the permissions correctly.