### PR TITLE
Compression

### DIFF
--- a/archivex.go
+++ b/archivex.go
@@ -155,6 +155,7 @@ func (t *TarFile) Create(name string) error {
 		// is it .zip? replace it
 		if strings.HasSuffix(name, ".zip") == true {
 			name = strings.Replace(name, ".zip", ".tar.gz", -1)
+			t.Compressed = true
 		} else {
 			// if it's not, add .tar
 			// since we'll assume it's not compressed

--- a/archivex.go
+++ b/archivex.go
@@ -158,7 +158,7 @@ func (t *TarFile) Create(name string) error {
 // Add add byte in archive tar
 func (t *TarFile) Add(name string, file []byte) error {
 
-	hdr := &tar.Header{Name: name, Size: int64(len(file)), Mode: 0777}
+	hdr := &tar.Header{Name: name, Size: int64(len(file)), Mode: 0666}
 	if err := t.Writer.WriteHeader(hdr); err != nil {
 		return err
 	}


### PR DESCRIPTION
While the library names the files ".tar.gz" it does not actually compress tar files with gzip. It just names them ".gz". For obvious reasons, this is confusing. 

I have edited the library to check for the naming of the file, if the file ends in .gz, it will assume compression. If it ends in .tar, it will assume no compression. If it ends in .zip and is a tar file, it will assume compression. If it doesn't have any suffix, it will assume no compression.

I think this is a reasonable way of managing compression, to let the user assign it via the naming of the archive.