### PR TITLE
AddFile() refactored to read file in blocks of 512kb.

### DIFF
--- a/archivex.go
+++ b/archivex.go
@@ -9,14 +9,14 @@ package archivex
 import (
 	"archive/tar"
 	"archive/zip"
+	"bufio"
 	"compress/gzip"
 	"io"
 	"io/ioutil"
 	"os"
 	"path"
-	"strings"
-	"bufio"
 	"path/filepath"
+	"strings"
 )
 
 // interface

--- a/archivex_test.go
+++ b/archivex_test.go
@@ -43,18 +43,18 @@ func Test_archivex(t *testing.T) {
 	// All the different tests we want to run with different combinations of input paths and the includeCurrentFolder flag
 	tests := []archTest{
 		// absolute path
-		archTest{dir + "/testfolder/", true, "absTrailInclude", /*dir +*/ "LICENSE", "string", "filename"},
-//		archTest{dir + "/testfolder/", false, "absTrailExclude", dir + "/LICENSE", "string", "filename"},
-//
-//		// relative path
-//		archTest{"testfolder/", true, "relTrailInclude", "LICENSE", "string", "filename"},
-//		archTest{"testfolder/", false, "relTrailExclude", "LICENSE", "string", "filename"},
-//
-//		// without trailing slashes
-//		archTest{dir + "/testfolder", true, "absInclude", dir + "/LICENSE", "string", "filename"},
-//		archTest{dir + "/testfolder", false, "absExclude", dir + "/LICENSE", "string", "filename"},
-//		archTest{"testfolder", true, "relInclude", "LICENSE", "string", "filename"},
-//		archTest{"testfolder", false, "relExclude", "LICENSE", "string", "filename"},
+		archTest{dir + "/testfolder/", true, "absTrailInclude", dir + "/LICENSE", "string", "filename"},
+		archTest{dir + "/testfolder/", false, "absTrailExclude", dir + "/LICENSE", "string", "filename"},
+
+		// relative path
+		archTest{"testfolder/", true, "relTrailInclude", "LICENSE", "string", "filename"},
+		archTest{"testfolder/", false, "relTrailExclude", "LICENSE", "string", "filename"},
+
+		// without trailing slashes
+		archTest{dir + "/testfolder", true, "absInclude", dir + "/LICENSE", "string", "filename"},
+		archTest{dir + "/testfolder", false, "absExclude", dir + "/LICENSE", "string", "filename"},
+		archTest{"testfolder", true, "relInclude", "LICENSE", "string", "filename"},
+		archTest{"testfolder", false, "relExclude", "LICENSE", "string", "filename"},
 	}
 
 	// We want to execute the batch of tests on both Zip and Tar
@@ -84,7 +84,7 @@ func Test_archivex(t *testing.T) {
 			}
 
 			// Add a file to the archive
-			if err := arch.AddFileInBlock(test.filePath, 200); err != nil {
+			if err := arch.AddFile(test.filePath); err != nil {
 				t.Fatalf("Error doing AddFile with '%s': %v", test.filePath, err)
 			}
 			//}

--- a/archivex_test.go
+++ b/archivex_test.go
@@ -8,8 +8,6 @@ package archivex
 
 import (
 	"fmt"
-
-	// "log"
 	"os"
 	"path"
 	"reflect"
@@ -31,7 +29,6 @@ type archTypeTest struct {
 }
 
 func Test_archivex(t *testing.T) {
-
 	dir, _ := os.Getwd()
 
 	// let's clean up the previous results, to be sure that we're not reading from an old result.
@@ -46,32 +43,32 @@ func Test_archivex(t *testing.T) {
 	// All the different tests we want to run with different combinations of input paths and the includeCurrentFolder flag
 	tests := []archTest{
 		// absolute path
-		archTest{dir + "/testfolder/", true, "absTrailInclude", dir + "/LICENSE", "string", "filename"},
-		archTest{dir + "/testfolder/", false, "absTrailExclude", dir + "/LICENSE", "string", "filename"},
-		// relative path
-		archTest{"testfolder/", true, "relTrailInclude", "LICENSE", "string", "filename"},
-		archTest{"testfolder/", false, "relTrailExclude", "LICENSE", "string", "filename"},
-		// without trailing slashes
-		archTest{dir + "/testfolder", true, "absInclude", dir + "/LICENSE", "string", "filename"},
-		archTest{dir + "/testfolder", false, "absExclude", dir + "/LICENSE", "string", "filename"},
-		archTest{"testfolder", true, "relInclude", "LICENSE", "string", "filename"},
-		archTest{"testfolder", false, "relExclude", "LICENSE", "string", "filename"},
+		archTest{dir + "/testfolder/", true, "absTrailInclude", /*dir +*/ "LICENSE", "string", "filename"},
+//		archTest{dir + "/testfolder/", false, "absTrailExclude", dir + "/LICENSE", "string", "filename"},
+//
+//		// relative path
+//		archTest{"testfolder/", true, "relTrailInclude", "LICENSE", "string", "filename"},
+//		archTest{"testfolder/", false, "relTrailExclude", "LICENSE", "string", "filename"},
+//
+//		// without trailing slashes
+//		archTest{dir + "/testfolder", true, "absInclude", dir + "/LICENSE", "string", "filename"},
+//		archTest{dir + "/testfolder", false, "absExclude", dir + "/LICENSE", "string", "filename"},
+//		archTest{"testfolder", true, "relInclude", "LICENSE", "string", "filename"},
+//		archTest{"testfolder", false, "relExclude", "LICENSE", "string", "filename"},
 	}
 
 	// We want to execute the batch of tests on both Zip and Tar
 	typeTests := []archTypeTest{
 		archTypeTest{tests, &ZipFile{}},
-		archTypeTest{tests, &TarFile{}},
+//		archTypeTest{tests, &TarFile{}},
 	}
 
 	// Run all tests
 	for _, typeTest := range typeTests {
-
 		currentType := reflect.TypeOf(typeTest.arch)
 		t.Logf("Running tests for archive type: %s", currentType.Elem())
 
 		for i, test := range typeTest.tests {
-
 			t.Logf("Running %s...", test.name)
 
 			// Create the archive
@@ -87,7 +84,7 @@ func Test_archivex(t *testing.T) {
 			}
 
 			// Add a file to the archive
-			if err := arch.AddFile(test.filePath); err != nil {
+			if err := arch.AddFileInBlock(test.filePath, 200); err != nil {
 				t.Fatalf("Error doing AddFile with '%s': %v", test.filePath, err)
 			}
 			//}
@@ -99,7 +96,6 @@ func Test_archivex(t *testing.T) {
 
 			// Close the archive
 			arch.Close()
-
 		}
 	}
 }

--- a/archivex_test.go
+++ b/archivex_test.go
@@ -60,7 +60,7 @@ func Test_archivex(t *testing.T) {
 	// We want to execute the batch of tests on both Zip and Tar
 	typeTests := []archTypeTest{
 		archTypeTest{tests, &ZipFile{}},
-//		archTypeTest{tests, &TarFile{}},
+		archTypeTest{tests, &TarFile{}},
 	}
 
 	// Run all tests


### PR DESCRIPTION
Dear,
Upload a file with millions of rows into memory at one time to add it to a zip seems to be bad.
This pullrequest reads the file in blocks of 512kb.
What do you think?