### PR TITLE
Fixes tar creation error

### DIFF
--- a/archivex.go
+++ b/archivex.go
@@ -243,10 +243,14 @@ func (t *TarFile) AddFile(name string) error {
 		return err
 	}
 
+	fmt.Println(info)
+
 	header, err := tar.FileInfoHeader(info, "")
 	if err != nil {
 		return err
 	}
+
+	fmt.Println(header.Name)
 
 	err = t.Writer.WriteHeader(header)
 	if err != nil {
@@ -257,7 +261,35 @@ func (t *TarFile) AddFile(name string) error {
 		return err
 	}
 	return nil
+}
 
+// AddFile add file from dir in archive tar
+func (t *TarFile) AddFileWithName(name string, filename string) error {
+	bytearq, err := ioutil.ReadFile(name)
+	if err != nil {
+		return err
+	}
+
+	info, err := os.Stat(name)
+	if err != nil {
+		return err
+	}
+
+	header, err := tar.FileInfoHeader(info, "")
+	if err != nil {
+		return err
+	}
+	header.Name = filename
+
+	err = t.Writer.WriteHeader(header)
+	if err != nil {
+		return err
+	}
+	_, err = t.Writer.Write(bytearq)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // AddAll adds all files from dir in archive

--- a/archivex.go
+++ b/archivex.go
@@ -11,6 +11,7 @@ import (
 	"archive/zip"
 	"bufio"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -18,7 +19,6 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-	"fmt"
 )
 
 // interface


### PR DESCRIPTION
I accidentally closed the writers in the wrong order, this lead to invalid tar files being created. Now I'm closing them in the right order, and the tar files are valid.