### PR TITLE
When using AddAll with includeCurrentFolder=false, remove leading slashes from subdirectories within the archive.

### DIFF
--- a/archivex.go
+++ b/archivex.go
@@ -342,6 +342,10 @@ func (t *TarFile) Close() error {
 func getSubDir(dir string, rootDir string, includeCurrentFolder bool) (subDir string) {
 
 	subDir = strings.Replace(dir, rootDir, "", 1)
+	// Remove leading slashes, since this is intentionally a subdirectory.
+	if len(subDir) > 0 && subDir[0] == os.PathSeparator {
+		subDir = subDir[1:]
+	}
 
 	if includeCurrentFolder {
 		parts := strings.Split(rootDir, string(os.PathSeparator))


### PR DESCRIPTION
Title says it all.  I would run "unzip -t blah.zip", and the files listed in the zip that were in subdirectories would have leading slashes only on the directories, not the files.  This pull removes the leading slash from subdirectories in getSubDir, prior to any Join'ing that occurs.