### PR TITLE
Add support for writing to io.Writers other than a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ _testmain.go
 *.test
 *.prof
 
+.idea
 .DS_Store
 filetest.*
 testresults

--- a/archivex.go
+++ b/archivex.go
@@ -26,6 +26,7 @@ type Archivex interface {
 	CreateWriter(name string, w io.Writer) error
 	Add(name string, file []byte) error
 	AddFile(name string) error
+	AddFileWithName(name string, filename string) error
 	AddAll(dir string, includeCurrentFolder bool) error
 	Close() error
 }


### PR DESCRIPTION
Currently the library only allows you to write TAR/ZIPs to a file. For my application it is needed to write them directly to a http.ResponseWriter. This backwards compatible change allows that by using the CreateWriter instead of Create.

I also need to use the AddFileWithName() function directly, so I added that to the interface as well. (This required no further code changes, so I dont think it will harm anyone)