### PR TITLE
PR_golang-github-jhoonb-archivex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ language: go
 go:
   - 1.4
   - tip
+# Excluding go: 1.4 as the same is not supported on Ubuntu16.04 for arch: ppc64le
+jobs: 
+ exclude:
+  - arch: ppc64le
+    go: 1.4
 
 install: go get -v ./...
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+  - ppc64le
+  - amd64
 language: go
 
 go:


### PR DESCRIPTION
Adding power support ppc64le

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

Excluding go: 1.4 as the same is not supported on Ubuntu16.04 for arch: ppc64le.
The build is successful for rest all.
